### PR TITLE
Remove array prototype

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1,7 +1,3 @@
-Array.prototype.last = function() {
-    return this[this.length-1];
-}
-
 require(["jquery", "goi-machine"],
 	function ($, machine) {
 		$("#btn-play").click(function(event) {

--- a/js/nodes/abs.js
+++ b/js/nodes/abs.js
@@ -10,7 +10,7 @@ define(['node', 'token', 'nodes/app', 'nodes/expo'], function(Node, Token, App, 
 		
 		transition(token, link) {
 			if (link.to == this.key && link.toPort == "s") {
-				var data = token.dataStack.last();
+				var data = token.dataStack[token.dataStack.length - 1];
 				if (data == CompData.PROMPT) {
 					token.dataStack.pop();
 					token.dataStack.push([CompData.LAMBDA,CompData.EMPTY]);

--- a/js/nodes/binop.js
+++ b/js/nodes/binop.js
@@ -47,7 +47,7 @@ define(['node', 'token', 'link', 'box-wrapper', 'nodes/promo', 'nodes/const', 'o
 
 				if (left instanceof Promo && right instanceof Promo) {
 					var wrapper = BoxWrapper.create().addToGroup(this.group);
-					var newConst = new Const(token.dataStack.last()[0]).addToGroup(wrapper.box);
+					var newConst = new Const(token.dataStack[token.dataStack.length - 1][0]).addToGroup(wrapper.box);
 					new Link(wrapper.prin.key, newConst.key, "n", "s").addToGroup(wrapper);
 					nextLink.changeTo(wrapper.prin.key, "s");
 					

--- a/js/nodes/const.js
+++ b/js/nodes/const.js
@@ -9,7 +9,7 @@ define(['node', 'token'], function(Node, Token) {
 		}
 		
 		transition(token, link) {
-			if (token.dataStack.last() == CompData.PROMPT) {
+			if (token.dataStack[token.dataStack.length - 1] == CompData.PROMPT) {
 				token.dataStack.pop();
 				token.dataStack.push([this.name,CompData.EMPTY]);
 				token.forward = false;

--- a/js/nodes/contract.js
+++ b/js/nodes/contract.js
@@ -41,13 +41,13 @@ define(['token', 'nodes/expo'], function(Token, Expo) {
 					this.delete();
 				}
 				else {
-					var i = token.boxStack.last();
+					var i = token.boxStack[token.boxStack.length - 1];
 					var prev = this.graph.findNodeByKey(i.from);
 					if (prev instanceof Contract) {
 						token.boxStack.pop();
 						/*
 						for (let _token of Array.from(nextLink.tokens)) {
-							if (_token.boxStack.last() == i)
+							if (_token.boxStack[token.boxStack.length - 1] == i)
 								_token.boxStack.pop();
 						}
 						for (let _token of Array.from(i.tokens)) {

--- a/js/nodes/delta.js
+++ b/js/nodes/delta.js
@@ -42,7 +42,7 @@ define(['node', 'token', 'box-wrapper', 'nodes/const', 'link', 'nodes/weak'],
 				var key = token.rewriteFlag.substring(3,token.rewriteFlag.length);
 				token.rewriteFlag = RewriteFlag.EMPTY;
 
-				var data = token.dataStack.last();
+				var data = token.dataStack[token.dataStack.length - 1];
 				var weak1 = new Weak().addToGroup(this.group);
 				this.findLinksOutOf("w")[0].changeFrom(weak1.key, "n");
 

--- a/js/nodes/dep.js
+++ b/js/nodes/dep.js
@@ -30,7 +30,7 @@ define(['node', 'token', 'box-wrapper', 'nodes/const', 'link', 'nodes/weak', 'he
 		rewrite(token, nextLink) {
 			if (nextLink.to == this.key && token.rewriteFlag == RewriteFlag.F_DEP) {
 				token.rewriteFlag = RewriteFlag.EMPTY;
-				var data = token.dataStack.last();
+				var data = token.dataStack[token.dataStack.length - 1];
 
 				if ((Helper.isNumber(data[0]) || typeof(data[0]) === "boolean")) {
 					var outLink = this.findLinksOutOf(null)[0]; 

--- a/js/nodes/if.js
+++ b/js/nodes/if.js
@@ -19,14 +19,14 @@ define(['node', 'token', 'nodes/promo', 'nodes/weak'],
 			else if (link.from == this.key && link.fromPort == "w") {
 				var left = this.graph.findNodeByKey(this.findLinksOutOf("w")[0].to);
 				if (left instanceof Promo) {
-					if (token.dataStack.last()[0] == true) {
+					if (token.dataStack[token.dataStack.length - 1][0] == true) {
 						var nextLink = this.findLinksOutOf("n")[0];
 						token.dataStack.pop();
 						token.rewriteFlag = RewriteFlag.F_IF;
 						token.forward = true;
 						return nextLink; 
 					}
-					else if (token.dataStack.last()[0] == false) {
+					else if (token.dataStack[token.dataStack.length - 1][0] == false) {
 						var nextLink = this.findLinksOutOf("e")[0];
 						token.dataStack.pop();
 						token.rewriteFlag = RewriteFlag.F_IF;

--- a/js/nodes/mod.js
+++ b/js/nodes/mod.js
@@ -21,7 +21,7 @@ define(['node', 'token', 'nodes/delta', 'nodes/weak', 'nodes/contract', 'helper'
 				return this.findLinksInto(null)[0]; 
 			}
 			else if (link.from == this.key && link.fromPort == "e") {
-				token.machine.newValues.set(this.key, token.dataStack.last()[0]);
+				token.machine.newValues.set(this.key, token.dataStack[token.dataStack.length - 1][0]);
 				token.delete();
 				return null;
 			}

--- a/js/nodes/prop.js
+++ b/js/nodes/prop.js
@@ -12,7 +12,7 @@ define(['node', 'token', 'box-wrapper', 'nodes/const', 'link'],
 
 		transition(token, link) {
 			if (link.to == this.key) {
-				if (token.dataStack.last() == CompData.PROMPT) {
+				if (token.dataStack[token.dataStack.length - 1] == CompData.PROMPT) {
 					token.dataStack.pop();
 					token.dataStack.push(false);
 					token.rewriteFlag = RewriteFlag.F_PROP;

--- a/js/nodes/set.js
+++ b/js/nodes/set.js
@@ -46,7 +46,7 @@ define(['node', 'token', 'box-wrapper', 'nodes/const', 'link', 'nodes/weak'],
 				var data = s[1];
 				token.rewriteFlag = RewriteFlag.EMPTY;
 
-				var data = token.dataStack.last();
+				var data = token.dataStack[token.dataStack.length - 1];
 				var weak1 = new Weak().addToGroup(this.group);
 				this.findLinksOutOf("w")[0].changeFrom(weak1.key, "n");
 

--- a/js/nodes/start.js
+++ b/js/nodes/start.js
@@ -9,7 +9,7 @@ define(['node', 'token'], function(Node, Token) {
 		}
 		
 		transition(token) {
-			if (token.link == null && token.dataStack.last() == CompData.PROMPT) {
+			if (token.link == null && token.dataStack[token.dataStack.length - 1] == CompData.PROMPT) {
 				var nextLink = this.findLinksOutOf(null)[0];
 				token.forward = true;
 				return nextLink;

--- a/js/nodes/unop.js
+++ b/js/nodes/unop.js
@@ -37,7 +37,7 @@ define(['node', 'token', 'link', 'box-wrapper', 'nodes/promo', 'nodes/const', 'o
 				var prev = this.graph.findNodeByKey(this.findLinksOutOf(null)[0].to);
 				if (prev instanceof Promo) {
 					var wrapper = BoxWrapper.create().addToGroup(this.group);
-					var newConst = new Const(token.dataStack.last()[0]).addToGroup(wrapper.box);
+					var newConst = new Const(token.dataStack[token.dataStack.length - 1][0]).addToGroup(wrapper.box);
 					new Link(wrapper.prin.key, newConst.key, "n", "s").addToGroup(wrapper);
 					nextLink.changeTo(wrapper.prin.key, "s");
 					prev.group.delete(); 

--- a/main.js
+++ b/main.js
@@ -15,7 +15,7 @@ requirejs.config({
 		renderer: '../bower_components/graphviz-d3-renderer/dist/renderer',
 		jquery: '../bower_components/jquery/dist/jquery',
 		// "goi-machine": './goi-machine',
-		"goi-machine": '../../tas458/lib/EFSD/v1/main.requirejs',
+		"goi-machine": '../../tas458/lib/EFSD/v1/goi-machine.requirejs',
 	},
 	shim: {
 		jquery: {


### PR DESCRIPTION
Defining prototype functions can be risky, and in this case it is inconvenient because it makes the code messy and hard to read, as well as it results in weird Prepack code.