### PR TITLE
Re-write app.js to use trampolines

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -10,9 +10,14 @@ define(["goi-machine"],
 			// global variables used to set-up timeouts to avoid stack overflow 
 			var termCalls = 0;
 			maxTermCalls = maxTermCalls || 125;
-			var CALLBACK_TIMEOUT = 0;
 
-			function interpret (program, callback, addTiming) {
+			function trampoline (res) {
+				while (res && res.fn) {
+					res = res.fn.apply(null, res.args);
+				}
+			}
+
+			function interpret (program, callback) {
 				// start time
 				if (addTiming) {
 					if (global.__residual) {
@@ -29,7 +34,10 @@ define(["goi-machine"],
 				machine.setPlay(true);
 				machine.setFinished(false);
 				if (!machine.isPlaying()) {
-					autoPlay(callback);
+					return {
+						fn: autoPlay,
+						args: [callback]
+					};
 				}
 			}
 	
@@ -42,54 +50,46 @@ define(["goi-machine"],
 				} 
 				if (machine.isFinished()) {
 					if (typeof result === 'function') {
-						callback(null, function () {
-							machine.setPlay(false);
-							machine.setPlaying(false);
-							// can only receive one argument at a time so this work
-							if (arguments.length !== 0 ) {
-								result(arguments[0]);
-							}
-							machine.setPlay(true);
-							machine.setFinished(false);
-							if (!machine.isPlaying()) {
-								autoPlay(callback);
-							}
-						});
+						return {
+							fn: callback,
+							args: [null, function () {
+								machine.setPlay(false);
+								machine.setPlaying(false);
+								// can only receive one argument at a time so this work
+								if (arguments.length !== 0 ) {
+									result(arguments[0]);
+								}
+								machine.setPlay(true);
+								machine.setFinished(false);
+								if (!machine.isPlaying()) {
+									return trampoline({
+										fn: autoPlay,
+										args: callback
+									});
+								}
+							}]
+						};
 					} else {
-						callback(null, result);
+						return {
+							fn: callback,
+							args: [null, result]
+						};
 					}
 				} else {
 					if (machine.isPlay()) {
-						if (global.__residual) {
-							// if we're in Prepack, and weve reached its maximum nubmer of calls
-							if (termCalls > maxTermCalls/3) {
-								if (termCalls > maxTermCalls) {
-									// set to 0 because up till now Prepack evaluated everything
-									termCalls = 0;
-									global.__residual("void", function(autoPlay, callback) {
-										autoPlay (callback);
-									}, autoPlay, callback);
-								} else {
-									termCalls--;
-									setTimeout(function () {
-										autoPlay (callback);
-									}, CALLBACK_TIMEOUT);
-								}
-							} else {
-								// just call the function as it is
-								autoPlay (callback);
-							}	
+						if (global.__residual && termCalls > maxTermCalls) {
+							// set to 0 because up till now Prepack evaluated everything
+							global.__residual("void", function(trampoline, autoPlay, callback) {
+								return trampoline({
+									fn: autoPlay,
+									args: [callback]
+								});
+							}, trampoline, autoPlay, callback);
 						} else {
-							// otherwise, if we've reached the maximum number of calls on the stack
-							if (termCalls > maxTermCalls) {
-								// call the function with a timeout
-								setTimeout(function () {
-									autoPlay (callback);
-								}, CALLBACK_TIMEOUT);
-							} else {
-								// just call the function as it is
-								autoPlay (callback);
-							}		
+							return {
+								fn: autoPlay,
+								args: [callback]
+							};
 						}
 					} else {
 						machine.setPlaying(false);
@@ -97,19 +97,25 @@ define(["goi-machine"],
 				}
 			}
 
-			interpret(program, function (err, result) {
-				// end time
-				if (addTiming) {
-					if (global.__residual) {
-						global.__residual('void', console => {
+			trampoline({
+				fn: interpret,
+				args: [program, function (err, result) {
+					// end time
+					if (addTiming) {
+						if (global.__residual) {
+							global.__residual('void', console => {
+								console.timeEnd('time');
+							}, abstractedConsole);
+						} else {
 							console.timeEnd('time');
-						}, abstractedConsole);
-					} else {
-						console.timeEnd('time');
-					}
-				} 
-				mainCallback(err, result);
-			}, addTiming);
+						}
+					} 
+					return {
+						fn: mainCallback,
+						args: [err, result]
+					};
+				}]
+			});
 		};
 	}
 );


### PR DESCRIPTION
The recursive "interpreter" was taking a very long time on the benchmarks, so attempted to implement the continuation-passing style interpreter. This is the result.

Benchmarks that took minutes without finishing now come back with results almost instantaneously.